### PR TITLE
Dynamic aggregation window mt base

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Setting `--prevent-server-caching=false` is only recommended when a sufficiently
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|
 |`util_95th`|95th percentile of deployment utilization percentage as reported by the service.|yes|`91.2%`|
 
+Note: Prior to the run reaching `aggregation-window` in elapsed time, sliding window stats will be calculated over the time elapsed since starting the test.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Setting `--prevent-server-caching=false` is only recommended when a sufficiently
 |`util_avg`|Average deployment utilization percentage as reported by the service.|yes|`89.3%`|
 |`util_95th`|95th percentile of deployment utilization percentage as reported by the service.|yes|`91.2%`|
 
-Note: Prior to the run reaching `aggregation-window` in elapsed time, sliding window stats will be calculated over the time elapsed since starting the test.
+Note: Prior to the benchmarking run reaching `aggregation-window` in elapsed time, all sliding window stats will be calculated over a dynamic window, equal to the time elapsed since starting the test. This ensures RPM/TPM stats are relatively accurate prior to the test reaching completion, including when a test ends early due to reaching the request limit.
 
 ## Contributing
 

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -152,7 +152,7 @@ class _StatsAggregator(threading.Thread):
          tbt_95th = round(np.percentile(self.token_latencies._values(), 95), 3) if self.token_latencies._len() > 1 else "n/a"
          util_avg = f"{round(np.average(self.utilizations._values()), 1)}%" if self.utilizations._len() > 0 else "n/a"
          util_95th = f"{round(np.percentile(self.utilizations._values(), 95), 1)}%" if self.utilizations._len() > 1 else "n/a"
-         rpm = round(60.0 * self.request_timestamps._len() / self.window_duration, 1)  if self.request_timestamps._len() > 0 else "n/a"
+         rpm = round(60.0 * self.request_timestamps._len() / dynamic_window, 1)  if self.request_timestamps._len() > 0 else "n/a"
          # Periodically warn if generated TPR is consistently lower than requested, which can result in higher scores for RPM compared to reality
          warning_period_secs = 10
          if all((

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -130,11 +130,13 @@ class _StatsAggregator(threading.Thread):
    def _dump(self):
       with self.lock:
          run_seconds = round(time.time() - self.start_time)
+         # Use dynamic aggregation window for when elapsed duration < window_duration
+         dynamic_window = min(run_seconds, self.window_duration)
          timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
          e2e_latency_avg = round(np.average(self.request_latency._values()), 3) if self.request_latency._len() > 0 else "n/a"
          e2e_latency_95th = round(np.percentile(self.request_latency._values(), 95), 3) if self.request_latency._len() > 1 else "n/a"
-         context_per_minute = round(60.0 * np.sum(self.context_tokens._values()) / self.window_duration, 0) if self.context_tokens._len() > 0 else "n/a"
-         gen_per_minute = round(60.0 * np.sum(self.generated_tokens._values()) / self.window_duration, 0) if self.generated_tokens._len() > 0 else "n/a"
+         context_per_minute = round(60.0 * np.sum(self.context_tokens._values()) / dynamic_window, 0) if self.context_tokens._len() > 0 else "n/a"
+         gen_per_minute = round(60.0 * np.sum(self.generated_tokens._values()) / dynamic_window, 0) if self.generated_tokens._len() > 0 else "n/a"
          tokens_per_minute = 0
          if context_per_minute != "n/a":
             tokens_per_minute += context_per_minute


### PR DESCRIPTION
Currently, all statistics are averaged over aggregation-window seconds, even when the test has not yet been running for that long. This means the RPM and TPM statistics will always start from zero and steadily increase to their correct values once the elapsed time has reached aggregation-window seconds, which can be confusing, and means it is difficult to diagnose any issues in configuration until the stats reach their correct values (which can be minutes later).

This PR fixes this by using a dynamic window size when calculating the windowed stats, which then reverts back to the original aggregation-window once the test has run for longer than it.