### PR TITLE
Log raw stats at end of run

### DIFF
--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -193,8 +193,13 @@ def _run_load(
         except Exception as e:
             print(e)
 
+    def finish_run_func():
+      """Function to run when run is finished."""
+      nonlocal aggregator
+      aggregator.dump_raw_call_stats()
+
     executer = AsyncHTTPExecuter(
-        request_func, rate_limiter=rate_limiter, max_concurrency=max_concurrency
+        request_func, rate_limiter=rate_limiter, max_concurrency=max_concurrency, finish_run_func=finish_run_func
     )
 
     aggregator.start()

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -74,6 +74,22 @@ class _StatsAggregator(threading.Thread):
 
       super(_StatsAggregator, self).__init__(*args, **kwargs)
 
+
+   def dump_raw_call_stats(self):
+      """Dumps raw stats for each individual call within the aggregation window"""
+      samples = {
+         "request_timestamps": self.request_timestamps._values(),
+         "request_latency": self.request_latency._values(),
+         "call_tries": self.call_tries._values(),
+         "response_latencies": self.response_latencies._values(),
+         "first_token_latencies": self.first_token_latencies._values(),
+         "token_latencies": self.token_latencies._values(),
+         "context_tokens": self.context_tokens._values(),
+         "generated_tokens": self.generated_tokens._values(),
+         "utilizations": self.utilizations._values(),
+      }
+      logger.info(f"All data samples: {json.dumps(samples)}")
+
    def run(self):
       """
       Start the periodic aggregator. Use stop() to stop.


### PR DESCRIPTION
This change logs all raw stats when the run ends, just prior to final termination.