### PR TITLE
Remove early termination of runs when draining begins

### DIFF
--- a/benchmark/contrib/batch_runner.py
+++ b/benchmark/contrib/batch_runner.py
@@ -389,7 +389,7 @@ def run_context_generation_batch(
         run_benchmark_exec_str(
             exec_str=benchmark_exec_str,
             print_terminal_output=True,
-            kill_when_draining_begins=True,
+            kill_when_draining_begins=False,
             kill_at_100_util=False,
         )
 


### PR DESCRIPTION
Within the batch runner, runs were killed when the limit is reached. When runs have long-running requests, this can mean that the draining of a run can begin prior to even the first request having been completed. This change prevents the termination of runs until all draining has completed.