### PR TITLE
Fix batch_runner shape arg

### DIFF
--- a/benchmark/contrib/batch_runner.py
+++ b/benchmark/contrib/batch_runner.py
@@ -180,7 +180,7 @@ def context_generation_run_to_exec_str(
         f"python3 -m benchmark.bench load {api_base_endpoint} --deployment {deployment} --context-tokens {context_tokens}"
         f" --max-tokens {max_tokens} --output-format jsonl --aggregation-window {aggregation_window} --clients {clients} "
         f"--prevent-server-caching {prevent_server_caching} --retry {retry} --api-key-env {api_key_env} "
-        " --context-generation-method generate"
+        " --context-generation-method generate --shape custom"
     )
     # Add optionals
     if rate is not None:


### PR DESCRIPTION
The batch_runner CLI did not have `--shape custom`, so every run was being run with the balanced shape (ignoring the `context_tokens` and `max_tokens` args)