### PR TITLE
Log avg number of context tokens in replay messages dataset

### DIFF
--- a/benchmark/messagegeneration.py
+++ b/benchmark/messagegeneration.py
@@ -149,7 +149,7 @@ class ReplayMessagesGenerator(BaseMessagesGenerator):
     def __init__(self, model: str, prevent_server_caching: bool, path: str):
         super().__init__(model, prevent_server_caching)
         # Load messages from file, checking structure
-        logging.info("loading replay messages from file...")
+        logging.info(f"loading replay messages from {path}...")
         try:
             with open(path, "r") as f:
                 all_messages_lists = json.load(f)
@@ -176,7 +176,7 @@ class ReplayMessagesGenerator(BaseMessagesGenerator):
             self._cached_messages_and_tokens.append((messages, messages_tokens))
 
         logging.info(
-            f"replay messages successfully loaded. average context tokens: {round(np.mean([x[1] for x in self._cached_messages_and_tokens]))}"
+            f"replay messages successfully loaded. average number of context_tokens across all messages: {round(np.mean([x[1] for x in self._cached_messages_and_tokens]))}"
         )
 
     def generate_messages(self) -> Tuple[Dict[str, str], int]:

--- a/benchmark/messagegeneration.py
+++ b/benchmark/messagegeneration.py
@@ -10,6 +10,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
+import numpy as np
 import wonderwords
 
 from benchmark.oaitokenizer import num_tokens_from_messages
@@ -148,7 +149,7 @@ class ReplayMessagesGenerator(BaseMessagesGenerator):
     def __init__(self, model: str, prevent_server_caching: bool, path: str):
         super().__init__(model, prevent_server_caching)
         # Load messages from file, checking structure
-        logging.info("loading messages from file")
+        logging.info("loading replay messages from file...")
         try:
             with open(path, "r") as f:
                 all_messages_lists = json.load(f)
@@ -173,6 +174,10 @@ class ReplayMessagesGenerator(BaseMessagesGenerator):
         for messages in all_messages_lists:
             messages_tokens = num_tokens_from_messages(messages, model)
             self._cached_messages_and_tokens.append((messages, messages_tokens))
+
+        logging.info(
+            f"replay messages successfully loaded. average context tokens: {round(np.mean([x[1] for x in self._cached_messages_and_tokens]))}"
+        )
 
     def generate_messages(self) -> Tuple[Dict[str, str], int]:
         """


### PR DESCRIPTION
Logs the average number of context tokens in the message in the replay messages dataset. This is important for understanding the token profile of the workload, and ensuring the rate is selected appropriately.