### PR TITLE
Improve saved log filename

### DIFF
--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -72,7 +72,7 @@ def main():
             token_config_str = f"shape={args.shape_profile}_context-tokens={args.context_tokens}_max-tokens={args.max_tokens}" if args.shape_profile == "custom" else f"shape={args.shape_profile}"
         else:
 
-            token_config_str = f"replay-filename={os.path.basename(args.replay_path)}_max-tokens={args.max_tokens}"
+            token_config_str = f"replay-basename={os.path.basename(args.replay_path).split('.')[0]}_max-tokens={args.max_tokens}"
         rate_str = str(int(args.rate)) if (args.rate is not None) else 'none'
         output_path = os.path.join(args.log_save_dir, f"{now}_{args.deployment}_{token_config_str}_clients={int(args.clients)}_rate={rate_str}.log")
         os.makedirs(args.log_save_dir, exist_ok=True)

--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -67,9 +67,14 @@ def main():
 
     if args.func is load and args.log_save_dir is not None:
         now = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        shape_str = f"context={args.context_tokens}_max_tokens={args.max_tokens}" if args.shape_profile == "custom" else args.shape_profile
+        # Create log file output
+        if args.context_generation_method == "generate":
+            token_config_str = f"shape={args.shape_profile}_context-tokens={args.context_tokens}_max-tokens={args.max_tokens}" if args.shape_profile == "custom" else f"shape={args.shape_profile}"
+        else:
+
+            token_config_str = f"replay-filename={os.path.basename(args.replay_path)}_max-tokens={args.max_tokens}"
         rate_str = str(int(args.rate)) if (args.rate is not None) else 'none'
-        output_path = os.path.join(args.log_save_dir, f"{now}_{args.deployment}_shape-{shape_str}_clients={int(args.clients)}_rate={rate_str}.log")
+        output_path = os.path.join(args.log_save_dir, f"{now}_{args.deployment}_{token_config_str}_clients={int(args.clients)}_rate={rate_str}.log")
         os.makedirs(args.log_save_dir, exist_ok=True)
         try:
             os.remove(output_path)


### PR DESCRIPTION
Improves the filename when saving files.

Using replay mode (filename is "test_replay_messages.json"):
`2024-02-28-14-32-14_gpt-35-turbo-0613_replay-basename=test_replay_messages_max-tokens=123_clients=20_rate=20.log`
Using custom shape:
`2024-02-28-14-29-04_gpt-35-turbo-0613_shape=custom_context-tokens=456_max-tokens=123_clients=20_rate=20.log`
Using a standard (non-custom) shape:
`2024-02-28-14-29-18_gpt-35-turbo-0613_shape=balanced_clients=20_rate=20.log`