### PR TITLE
Add `log-request-content` option and minor fixes/features

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ tokens: 65
 The `combine_logs` CLI can be used to load and combine the logs from multiple runs into a single CSV, ready for comparison and analysis. This tool extracts:
 * The arguments that were used to initiate the benchmarking run
 * The aggregate statistics of all requests in the run
-* With `--include-raw-call-info true`, the timestamps, call status and all input/output content of every individual request. This can be used to plot distributions of values, and start/finish of each individual request.
+* With `--include-raw-request-info true`, the timestamps, call status and all input/output content of every individual request will be extracted and saved into the combined CSV. This can be used to plot distributions of values, and start/finish of each individual request.
 
 Additionally, the `--load-recursive` arg will search not only in the provided directory, but all subdirectories as well.
 
@@ -155,7 +155,7 @@ $ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recurs
 
 # Extract aggregate AND individual call stats that were logged when the duration/requests limit was reached
 $ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive \
-    --stat-extraction-point draining --include-raw-call-info true
+    --stat-extraction-point draining --include-raw-request-info true
 
 # Extract the very last line of logs, after the very last request has finished
 $ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive \

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ python -m benchmark.bench load \
     https://myaccount.openai.azure.com
 ```
 
-**Load test with custom request shape**
+**Load test with custom request shape, and automatically save output to file**
 
 ```
 $ python -m benchmark.bench load \
@@ -100,6 +100,21 @@ $ python -m benchmark.bench load \
     --shape custom \
     --context-tokens 1000 \
     --max-tokens 500 \
+    --log-save-dir logs/ \
+    https://myaccount.openai.azure.com
+```
+
+**As above, but also record the timestamps, call status and input & output content of every individual request**
+
+```
+$ python -m benchmark.bench load \
+    --deployment gpt-4 \
+    --rate 1 \
+    --shape custom \
+    --context-tokens 1000 \
+    --max-tokens 500 \
+    --log-save-dir logs/ \
+    --log-request-content true \
     https://myaccount.openai.azure.com
 ```
 
@@ -125,15 +140,26 @@ tokens: 65
 ## Contibuted modules
 **Extract and Combine JSON logs to CSV**
 
-The `combine_logs` CLI can be used to load and combine the logs from multiple runs into a single CSV, ready for comparison and analysis. This tool extracts the run arguments, a valid set of aggregate statistics (as determined by `--stat-extraction-point`), and all raw request statistics of requests within the aggregation window at the end of the run. The `--load-recursive` arg will search not only in the provided directory, but all subdirectories as well.
+The `combine_logs` CLI can be used to load and combine the logs from multiple runs into a single CSV, ready for comparison and analysis. This tool extracts:
+* The arguments that were used to initiate the benchmarking run
+* The aggregate statistics of all requests in the run
+* With `--include-raw-call-info true`, the timestamps, call status and all input/output content of every individual request. This can be used to plot distributions of values, and start/finish of each individual request.
+
+Additionally, the `--load-recursive` arg will search not only in the provided directory, but all subdirectories as well.
 
 Note: The core benchmarking tool waits for any incomplete requests to 'drain' when the end of the run is reached, without replacing these requests with new ones. This can mean that overall TPM and RPM can begin to drop after the draining point as all remaining requests slowly finish, dragging the average TPM and RPM statistics down. For this reason, it is recommended to use `--stat-extraction-point draining` to extract the aggregate statistcs that were logged when draining began (and prior to any reduction in throughput). If however you are more interested in latency values and do not care about the RPM and TPM values, use `--stat-extraction-point final`, which will extract the very last line of logged statistics (which should include all completed requests that are still within the aggregation window).
 ```
 # Extract stats that were logged when the duration/requests limit was reached
-$ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive --stat-extraction-point draining
+$ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive \
+    --stat-extraction-point draining
+
+# Extract aggregate AND individual call stats that were logged when the duration/requests limit was reached
+$ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive \
+    --stat-extraction-point draining --include-raw-call-info true
 
 # Extract the very last line of logs, after the very last request has finished
-$ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive --stat-extraction-point final
+$ python -m benchmark.contrib.combine_logs logs/ combined_logs.csv --load-recursive \
+    --stat-extraction-point final
 ```
 
 **Run Batches of Multiple Configurations**
@@ -147,7 +173,7 @@ Example - Run a single batch with `context-generation-method=generate` with the 
 - context_tokens=3500, max_tokens=300, rate=7.5
 
 ```
-$ python -m benchmark.contrib.batch_runner https://gbb-ea-openai-swedencentral-01.openai.azure.com/ \
+$ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method generate \
     --token-rate-workload-list 500-100-20,3500-300-7.5 --duration 130 \
     --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true
@@ -156,7 +182,7 @@ $ python -m benchmark.contrib.batch_runner https://gbb-ea-openai-swedencentral-0
 Example - Run the same batch as above, but 5x times and with a 1 hour delay between the start of each batch:
 
 ```
-$ python -m benchmark.contrib.batch_runner https://gbb-ea-openai-swedencentral-01.openai.azure.com/ \
+$ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method generate \
     --token-rate-workload-list 500-100-20,3500-300-7.5 --duration 130 \
     --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true \
@@ -165,7 +191,7 @@ $ python -m benchmark.contrib.batch_runner https://gbb-ea-openai-swedencentral-0
 
 Example 3 - Run a batch using `context-generation-method=replay`. In this example, the first item in the token-rate-workload-list is the path to the replay messages dataset (see the next section for more info on how this works). Make sure that the replay messages filename does not contain dashes, and that the path is relative to the directory from which you are running the command:
 ```
-$ python -m benchmark.contrib.batch_runner https://gbb-ea-openai-swedencentral-01.openai.azure.com/ \
+$ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method replay \
     --token-rate-workload-list tests/test_replay_messages.json-100-20,tests/test_replay_messages.json-300-7.5 \
     --duration 130 --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The `batch_runner` CLI can be used to run batches of benchmark runs back-to-back
 
 To use the CLI, create a list of token profile and rate combinations to be used, and then select the number of batches and interval to be used between each batch. When using the batch runner with the commands below, make sure to execute the command from the root directory of the repo.
 
-Example - Run a single batch with `context-generation-method=generate` with the following two configurations for 120 seconds each, making sure to automatically warm up the endpoint prior to each run (if it is a PTU-M endpoint):
+Example - Run a single batch with `context-generation-method=generate` with the following two configurations for 120 seconds each, making sure to automatically warm up the endpoint prior to each run (if it is a PTU-M endpoint), and also saving all request input and output content from each run:
 - context_tokens=500,  max_tokens=100, rate=20
 - context_tokens=3500, max_tokens=300, rate=7.5
 
@@ -176,7 +176,8 @@ Example - Run a single batch with `context-generation-method=generate` with the 
 $ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method generate \
     --token-rate-workload-list 500-100-20,3500-300-7.5 --duration 130 \
-    --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true
+    --aggregation-window 120 --log-save-dir logs/ \
+    --start-ptum-runs-at-full-utilization true --log-request-content true
 ```
 
 Example - Run the same batch as above, but 5x times and with a 1 hour delay between the start of each batch:
@@ -185,7 +186,8 @@ Example - Run the same batch as above, but 5x times and with a 1 hour delay betw
 $ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method generate \
     --token-rate-workload-list 500-100-20,3500-300-7.5 --duration 130 \
-    --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true \
+    --aggregation-window 120 --log-save-dir logs/ \
+    --start-ptum-runs-at-full-utilization true --log-request-content true \
     --num-batches 5 --batch-start-interval 3600
 ```
 
@@ -194,7 +196,8 @@ Example 3 - Run a batch using `context-generation-method=replay`. In this exampl
 $ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
     --deployment gpt-4-1106-ptu --context-generation-method replay \
     --token-rate-workload-list tests/test_replay_messages.json-100-20,tests/test_replay_messages.json-300-7.5 \
-    --duration 130 --aggregation-window 120 --log-save-dir logs/ --start-ptum-runs-at-full-utilization true
+    --duration 130 --aggregation-window 120 --log-save-dir logs/ \
+    --start-ptum-runs-at-full-utilization true --log-request-content true \
 ```
 
 ## Configuration Option Details

--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -48,6 +48,7 @@ def main():
     load_parser.add_argument("--top-p", type=float, help="Request top_p.")
     load_parser.add_argument("-f", "--output-format", type=str, default="human", help="Output format.", choices=["jsonl", "human"])
     load_parser.add_argument("--log-save-dir", type=str, help="If provided, will save stddout to this directory. Filename will include important run parameters.")
+    load_parser.add_argument("--log-request-content", type=str2bool, nargs='?', help="If True, will log the raw input and output tokens of every request. Defaults to False.", const=True, default=False)
     load_parser.add_argument("-t", "--retry", type=str, default="none", help="Request retry strategy. See README for details", choices=["none", "exponential"])
     load_parser.add_argument("-e", "--deployment", type=str, help="Azure OpenAI deployment name.", required=True)
     load_parser.add_argument("api_base_endpoint", help="Azure OpenAI deployment base endpoint.", nargs=1)

--- a/benchmark/contrib/batch_runner.py
+++ b/benchmark/contrib/batch_runner.py
@@ -426,7 +426,8 @@ def validate_and_process_context_token_workload_list(
         raise ValueError(
             f"context-generation-method invalid - must be one of {valid_context_generation_methods}"
         )
-    print(token_rate_workload_list, context_generation_method)
+    if " " in token_rate_workload_list:
+        raise ValueError("Error: token-rate-workload-list must not contain spaces.")
     output = list()
     for item in token_rate_workload_list.split(","):
         split_vals = item.split("-")

--- a/benchmark/contrib/batch_runner.py
+++ b/benchmark/contrib/batch_runner.py
@@ -31,7 +31,6 @@ from ..oairequester import TELEMETRY_USER_AGENT_HEADER, USER_AGENT, UTILIZATION_
 
 def str2bool(v):
     if isinstance(v, bool):
-
         return v
     if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
@@ -106,6 +105,14 @@ def parse_args():
         help="If provided, will save stddout to this directory. Filename will include important run parameters.",
     )
     parser.add_argument(
+        "--log-request-content",
+        type=str2bool,
+        nargs="?",
+        help="If True, will log the raw input and output tokens of every request. Defaults to False.",
+        const=True,
+        default=False,
+    )
+    parser.add_argument(
         "--retry",
         type=str,
         default="none",
@@ -175,6 +182,7 @@ def benchmark_args_to_exec_str(
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     log_save_dir: Optional[str] = None,
+    log_request_content: Optional[bool] = None,
     api_key_env: str = "OPENAI_API_KEY",
 ):
     """Converts args into an execution string for the benchmarking script."""
@@ -200,6 +208,8 @@ def benchmark_args_to_exec_str(
         cmd += f" --run-end-condition-mode {run_end_condition_mode}"
     if log_save_dir is not None:
         cmd += f" --log-save-dir {log_save_dir}"
+    if log_request_content is not None:
+        cmd += f" --log-request-content {log_request_content}"
     if frequency_penalty is not None:
         cmd += f" --frequency-penalty {requests}"
     if presence_penalty is not None:
@@ -276,6 +286,7 @@ def run_benchmark_batch(
     run_end_condition_mode: str,
     clients: Optional[int],
     log_save_dir: str,
+    log_request_content: Optional[bool],
     prevent_server_caching: bool,
     start_ptum_runs_at_full_utilization: bool,
     retry: str,
@@ -298,6 +309,7 @@ def run_benchmark_batch(
     :param run_end_condition_mode: Determines whether both the `requests` and `duration` args must be reached before ending the run ('and'), or whether to end the run either either arg is reached ('or'). Defaults to 'or'.
     :param clients: Number of clients to use in each test.
     :param log_save_dir: Will save all logs to this directory.
+    :param log_request_content: If True, will log the raw input and output content of every request.
     :param prevent_server_caching: Whether to prevent server caching in each test.
     :param start_ptum_runs_at_full_utilization: For PTU-M deployments, run a high load run through the endpoint prior to each and every benchmark run to ensure benchmnark runs start at 100% utilization (avoiding the effect of burst capacity influencing the results).
     :param retry: Request retry strategy.
@@ -361,6 +373,7 @@ def run_benchmark_batch(
                 max_tokens=100,
                 rate=None,
                 log_save_dir=None,
+                log_request_content=False,
                 aggregation_window=60,
                 duration=None,
                 requests=None,
@@ -396,6 +409,7 @@ def run_benchmark_batch(
             max_tokens=max_tokens,
             rate=rate,
             log_save_dir=log_save_dir,
+            log_request_content=log_request_content,
             aggregation_window=aggregation_window,
             duration=duration,
             requests=requests,
@@ -493,6 +507,7 @@ def main():
                 run_end_condition_mode=args.run_end_condition_mode,
                 clients=args.clients,
                 log_save_dir=args.log_save_dir,
+                log_request_content=args.log_request_content,
                 prevent_server_caching=args.prevent_server_caching,
                 start_ptum_runs_at_full_utilization=args.start_ptum_runs_at_full_utilization,
                 frequency_penalty=args.frequency_penalty,
@@ -530,6 +545,7 @@ def main():
                     run_end_condition_mode=args.run_end_condition_mode,
                     clients=args.clients,
                     log_save_dir=args.log_save_dir,
+                    log_request_content=args.log_request_content,
                     prevent_server_caching=args.prevent_server_caching,
                     start_ptum_runs_at_full_utilization=args.start_ptum_runs_at_full_utilization,
                     frequency_penalty=args.frequency_penalty,

--- a/benchmark/contrib/combine_logs.py
+++ b/benchmark/contrib/combine_logs.py
@@ -77,6 +77,7 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) ->
         return None
     run_args["early_terminated"] = early_terminated
     run_args["filename"] = Path(log_file).name
+    run_args["filepath"] = log_file
     # Extract last line of valid stats from log if available
     if last_logged_stats:
         last_logged_stats = flatten_dict(json.loads(last_logged_stats))
@@ -84,6 +85,7 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) ->
         run_args["run_has_non_throttled_failures"] = (
             int(run_args["failures"]) - int(run_args["throttled"]) > 0
         )
+    run_args["confirmed_as_ptu_endpoint]"] = last_logged_stats["util"]["avg"] != "n/a"
     run_args["raw_samples"] = raw_samples
     return run_args
 

--- a/benchmark/contrib/combine_logs.py
+++ b/benchmark/contrib/combine_logs.py
@@ -23,7 +23,7 @@ def combine_logs_to_csv(
         save_path = args.save_path + ".csv"
         logging.info(f"Warning: `save_path` does not end with .csv. Appending .csv to save_path. New path: {save_path}")
     log_dir = args.source_dir
-    save_path = args.save_path
+    include_raw_call_info = args.include_raw_call_info
     stat_extraction_point = args.stat_extraction_point
     load_recursive = args.load_recursive
 
@@ -31,7 +31,7 @@ def combine_logs_to_csv(
     log_files = log_dir.rglob("*.log") if load_recursive else log_dir.glob("*.log")
     log_files = sorted(log_files)
     # Extract run info from each log file
-    run_summaries = [extract_run_info_from_log_path(log_file, stat_extraction_point) for log_file in log_files]
+    run_summaries = [extract_run_info_from_log_path(log_file, stat_extraction_point, include_raw_call_info) for log_file in log_files]
     run_summaries = [summary for summary in run_summaries if isinstance(summary, dict)]
     # Convert to dataframe and save to csv
     if run_summaries:
@@ -44,7 +44,7 @@ def combine_logs_to_csv(
     return
 
 
-def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) -> Optional[dict]:
+def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str, include_raw_call_info: bool) -> Optional[dict]:
     """Extracts run info from log file path"""
     assert stat_extraction_point in ["draining", "final"], "stat_extraction_point must be either 'draining' or 'final'"
     is_format_human = False
@@ -52,6 +52,7 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) ->
     last_logged_stats = None
     raw_samples = None
     early_terminated = False
+    is_confirmed_as_ptu_endpoint = False
     is_draining_commenced = False
     prevent_reading_new_stats = False
     # Process lines, including only info BEFORE early termination (for terminated sessions), or the final log AFFTER requests start to drain (for valid sessions)
@@ -76,8 +77,8 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) ->
             if "requests to drain" in line:
                 # Current line is draining, next line is the last set of valid stats. Allow one more line to be processed.
                 is_draining_commenced = True
-            if "Raw call stats: " in line:
-                raw_samples = line.split("Raw call stats: ")[-1] # Do not load - output as string
+            if include_raw_call_info and "Raw call stats: " in line:
+                raw_samples = line.split("Raw call stats: ")[-1] # Do not load as json - output as string
     if is_format_human:
         logging.error(
             f"Could not extract run args from log file {log_file} - Data was collected with `--output-format human` (the default value). Please rerun the tests with `--output-format jsonl`."
@@ -98,7 +99,8 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str) ->
         run_args["run_has_non_throttled_failures"] = (
             int(run_args["failures"]) - int(run_args["throttled"]) > 0
         )
-    run_args["confirmed_as_ptu_endpoint]"] = last_logged_stats["util_avg"] != "n/a"
+        is_confirmed_as_ptu_endpoint = last_logged_stats["util_avg"] != "n/a"
+    run_args["is_confirmed_as_ptu_endpoint"] = is_confirmed_as_ptu_endpoint
     run_args["raw_samples"] = raw_samples
     return run_args
 
@@ -149,7 +151,19 @@ def main():
         "save_path", type=str, help="Path to save the output output CSV."
     )
     parser.add_argument(
-        "--stat-extraction-point", type=str, help="The point from which to extract statistics. If set to `draining`, stats are extraced when requests start draining, but before all requests have finished. If set to `final`, the very last line of stats are used, which could result in lower aggregate TPM/RPM numbers. See the README for more info.", choices=["draining", "final"], default="draining"
+        "--include-raw-call-info", 
+        type=str2bool, 
+        nargs='?', 
+        help="If True, all raw request info (timestamps, call status, request content) will be included for each individual request in every run where it is available.",
+        const=True,
+        default=True
+    )
+    parser.add_argument(
+        "--stat-extraction-point", 
+        type=str, 
+        help="The point from which to extract statistics. If set to `draining`, stats are extraced when requests start draining, but before all requests have finished. If set to `final`, the very last line of stats are used, which could result in lower aggregate TPM/RPM numbers. See the README for more info.", 
+        choices=["draining", "final"], 
+        default="draining"
     )
     parser.add_argument(
         "--load-recursive",
@@ -160,5 +174,14 @@ def main():
     args = parser.parse_args()
     combine_logs_to_csv(args)
 
-
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+    
 main()

--- a/benchmark/contrib/combine_logs.py
+++ b/benchmark/contrib/combine_logs.py
@@ -23,7 +23,7 @@ def combine_logs_to_csv(
         save_path = args.save_path + ".csv"
         logging.info(f"Warning: `save_path` does not end with .csv. Appending .csv to save_path. New path: {save_path}")
     log_dir = args.source_dir
-    include_raw_call_info = args.include_raw_call_info
+    include_raw_request_info = args.include_raw_request_info
     stat_extraction_point = args.stat_extraction_point
     load_recursive = args.load_recursive
 
@@ -31,7 +31,7 @@ def combine_logs_to_csv(
     log_files = log_dir.rglob("*.log") if load_recursive else log_dir.glob("*.log")
     log_files = sorted(log_files)
     # Extract run info from each log file
-    run_summaries = [extract_run_info_from_log_path(log_file, stat_extraction_point, include_raw_call_info) for log_file in log_files]
+    run_summaries = [extract_run_info_from_log_path(log_file, stat_extraction_point, include_raw_request_info) for log_file in log_files]
     run_summaries = [summary for summary in run_summaries if isinstance(summary, dict)]
     # Convert to dataframe and save to csv
     if run_summaries:
@@ -44,7 +44,7 @@ def combine_logs_to_csv(
     return
 
 
-def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str, include_raw_call_info: bool) -> Optional[dict]:
+def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str, include_raw_request_info: bool) -> Optional[dict]:
     """Extracts run info from log file path"""
     assert stat_extraction_point in ["draining", "final"], "stat_extraction_point must be either 'draining' or 'final'"
     is_format_human = False
@@ -77,7 +77,7 @@ def extract_run_info_from_log_path(log_file: str, stat_extraction_point: str, in
             if "requests to drain" in line:
                 # Current line is draining, next line is the last set of valid stats. Allow one more line to be processed.
                 is_draining_commenced = True
-            if include_raw_call_info and "Raw call stats: " in line:
+            if include_raw_request_info and "Raw call stats: " in line:
                 raw_samples = line.split("Raw call stats: ")[-1] # Do not load as json - output as string
     if is_format_human:
         logging.error(
@@ -151,7 +151,7 @@ def main():
         "save_path", type=str, help="Path to save the output output CSV."
     )
     parser.add_argument(
-        "--include-raw-call-info", 
+        "--include-raw-request-info", 
         type=str2bool, 
         nargs='?', 
         help="If True, all raw request info (timestamps, call status, request content) will be included for each individual request in every run where it is available.",

--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -170,6 +170,7 @@ def load(args):
         aggregation_duration=args.aggregation_window,
         run_end_condition_mode=args.run_end_condition_mode,
         json_output=args.output_format == "jsonl",
+        log_request_content=args.log_request_content
     )
 
 def _run_load(
@@ -184,13 +185,15 @@ def _run_load(
     request_count=None,
     run_end_condition_mode="or",
     json_output=False,
+    log_request_content=False
 ):
     aggregator = _StatsAggregator(
         window_duration=aggregation_duration,
         dump_duration=1, 
         expected_gen_tokens=request_builder.max_tokens,
         clients=max_concurrency,
-        json_output=json_output)
+        json_output=json_output,
+        log_request_content=log_request_content)
     requester = OAIRequester(api_key, url, backoff=backoff)
 
     async def request_func(session:aiohttp.ClientSession):

--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -95,6 +95,7 @@ def load(args):
         "temperature": args.temperature,
         "top_p": args.top_p,
         "output_format": args.output_format,
+        "log_request_content": args.log_request_content,
     }
     converted = json.dumps(run_args)
     logging.info("Load test args: " + converted)

--- a/benchmark/messagegeneration.py
+++ b/benchmark/messagegeneration.py
@@ -45,10 +45,9 @@ class BaseMessagesGenerator(ABC):
         Returns a modified copy of messages and an updated token count.
         """
         messages = copy.deepcopy(messages)
-        for message in messages:
-            message["content"] = str(time.time()) + " " + message["content"]
-            # Timestamps strings like "1704441942.868042 " use 8 tokens for OpenAI GPT models. Update token count
-            messages_tokens += 8
+        messages[0]["content"] = str(time.time()) + " " + messages[0]["content"]
+        # Timestamps strings like "1704441942.868042 " use 8 tokens for OpenAI GPT models. Update token count
+        messages_tokens += 8
         return (messages, messages_tokens)
 
     def remove_anticache_prefix(

--- a/benchmark/oairequester.py
+++ b/benchmark/oairequester.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import time
 from typing import Optional
+import json
 
 import aiohttp
 import backoff
@@ -34,9 +35,11 @@ class RequestStats:
         self.deployment_utilization: Optional[float] = None
         self.calls: int = 0
         self.last_exception: Optional[Exception] = None
+        self.input_messages: Optional[dict[str, str]] = None
+        self.output_content: list[dict] = list()
 
-    def as_dict(self) -> dict:
-        return {
+    def as_dict(self, include_request_content: bool = False) -> dict:
+        output = {
             "request_start_time": self.request_start_time,
             "response_status_code": self.response_status_code,
             "response_time": round(self.response_time, 4),
@@ -48,6 +51,10 @@ class RequestStats:
             "calls": self.calls,
             "last_exception": self.last_exception,
         }
+        if include_request_content:
+            output["input_messages"] = self.input_messages
+            output["output_content"] = self.output_content if self.output_content else None
+        return output
 
 def _terminal_http_code(e) -> bool:
     # we only retry on 429
@@ -80,6 +87,7 @@ class OAIRequester:
         :return RequestStats.
         """
         stats = RequestStats()
+        stats.input_messages = body["messages"]
         # operate only in streaming mode so we can collect token stats.
         body["stream"] = True
         try:
@@ -142,7 +150,18 @@ class OAIRequester:
                     stats.first_token_time = time.time()
                 if stats.generated_tokens is None:
                     stats.generated_tokens = 0
-                stats.generated_tokens += 1
+                # Save content from generated tokens
+                content = line.decode('utf-8')
+                if content == "data: [DONE]\n":
+                    # Request is finished - no more tokens to process
+                    break
+                content = json.loads(content.replace("data: ", ""))["choices"][0]["delta"]
+                if content:
+                    if next(iter(content)) == "role":
+                        stats.output_content.append({"role": content["role"], "content": ""})
+                    else:
+                        stats.output_content[-1]["content"] += content["content"]
+                    stats.generated_tokens += 1
             stats.response_end_time = time.time()
 
     def _read_utilization(self, response: aiohttp.ClientResponse, stats: RequestStats):

--- a/benchmark/oairequester.py
+++ b/benchmark/oairequester.py
@@ -42,9 +42,9 @@ class RequestStats:
         output = {
             "request_start_time": self.request_start_time,
             "response_status_code": self.response_status_code,
-            "response_time": round(self.response_time, 4),
-            "first_token_time": round(self.first_token_time, 4),
-            "response_end_time": round(self.response_end_time, 4),
+            "response_time": self.response_time,
+            "first_token_time": self.first_token_time,
+            "response_end_time": self.response_end_time,
             "context_tokens": self.context_tokens,
             "generated_tokens": self.generated_tokens,
             "deployment_utilization": self.deployment_utilization,

--- a/benchmark/oairequester.py
+++ b/benchmark/oairequester.py
@@ -35,6 +35,20 @@ class RequestStats:
         self.calls: int = 0
         self.last_exception: Optional[Exception] = None
 
+    def as_dict(self) -> dict:
+        return {
+            "request_start_time": self.request_start_time,
+            "response_status_code": self.response_status_code,
+            "response_time": round(self.response_time, 4),
+            "first_token_time": round(self.first_token_time, 4),
+            "response_end_time": round(self.response_end_time, 4),
+            "context_tokens": self.context_tokens,
+            "generated_tokens": self.generated_tokens,
+            "deployment_utilization": self.deployment_utilization,
+            "calls": self.calls,
+            "last_exception": self.last_exception,
+        }
+
 def _terminal_http_code(e) -> bool:
     # we only retry on 429
     return e.response.status != 429
@@ -109,6 +123,8 @@ class OAIRequester:
                 # fallback to backoff
                 break
 
+        if response.status != 200:
+            stats.response_end_time = time.time()
         if response.status != 200 and response.status != 429:
             logging.warning(f"call failed: {REQUEST_ID_HEADER}={response.headers[REQUEST_ID_HEADER]} {response.status}: {response.reason}")
         if self.backoff:

--- a/benchmark/statsaggregator.py
+++ b/benchmark/statsaggregator.py
@@ -60,19 +60,21 @@ class _StatsAggregator(threading.Thread):
 
    raw_stat_dicts = list()
 
-   def __init__(self, clients:int, dump_duration:float=5, window_duration:float=60, expected_gen_tokens: Optional[int] = None, json_output=False, *args,**kwargs):
+   def __init__(self, clients:int, dump_duration:float=5, window_duration:float=60, expected_gen_tokens: Optional[int] = None, json_output:bool=False, log_request_content:bool=False, *args,**kwargs):
       """
       :param clients: number of clients being used in testing.
       :param dump_duration: duration in seconds to dump current aggregates.
       :param window_duration: duration of sliding window in second to consider for aggregation.
       :param expected_gen_tokens: number of tokens expected in each response.
       :param json_output: whether to dump periodic stats as json or human readable.
+      :param log_request_content: whether to log request content in the raw call stat output.
       """
       self.clients = clients
       self.dump_duration = dump_duration
-      self.json_output = json_output
       self.window_duration = window_duration
       self.expected_gen_tokens = expected_gen_tokens
+      self.json_output = json_output
+      self.log_request_content = log_request_content
 
       super(_StatsAggregator, self).__init__(*args, **kwargs)
 
@@ -134,7 +136,7 @@ class _StatsAggregator(threading.Thread):
          if stats.deployment_utilization is not None:
             self.utilizations._append(stats.request_start_time, stats.deployment_utilization)
          # Save raw stat for the call
-         self.raw_stat_dicts.append(stats.as_dict())
+         self.raw_stat_dicts.append(stats.as_dict(include_request_content=self.log_request_content))
 
    def _dump(self):
       with self.lock:

--- a/tests/test_replay_messages.json
+++ b/tests/test_replay_messages.json
@@ -1,0 +1,12 @@
+[
+    [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Can you explain how photosynthesis works?"}
+    ],
+    [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What is the capital of France?"},
+      {"role": "assistant", "content": "The capital of France is Paris."},
+      {"role": "user", "content": "Please tell me about the history of Paris."}
+    ]
+]


### PR DESCRIPTION
Features included:
* Addition of `log-request-content` argument, which will log the input and output text content of every request in a benchmarking run. This works with the `bench` and `batch_runner` entrypoints.
* Minor bugfixes and tweaks, including:
    * Automatic appending of .csv when saving logs to file
    * Validate that no spaces are included in `token-rate-workload-list` within the `batch_runner`
    * When prepending the anti-cache timestamp (when --prevent-server-caching = true`), only add this to the first message rather than every message (This saves excess token usage).

Combined logs:
* `--include-raw-request-info` argument is added, which can include or exclude raw request stats and content in the combined output CSV. This is useful if individual request data is not required and you want to keep the file size of the combined CSV to a minimum.
* Detect when human readable format was used in the benchmark run, and make this clearer to the user.
* Addition of a `is_confirmed_as_ptu_endpoint` field in the output CSV (to allow filtering/grouping by deployment type), along with a `filepath` field (to more easily enable filtering based on full fill location).