### PR TITLE
Add adjust-for-network-latency feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $ python -m benchmark.contrib.batch_runner https://myaccount.openai.azure.com/ \
 ```
 
 ## Configuration Option Details
-### Context Generation Method
+#### Context Generation Method
 Using the `--context-generation-method` argument, this tool gives two options for how the source content of each request is generated:
 
 **1: `generate`** [default]: Context information is generated automatically from a list of all english words, and the endpoint is instructed to generate a long story of `max_tokens` words. This is useful where existing data is not yet available, and should reslt in similar performance as real-world workoads with the same number of context & completion tokens.
@@ -235,7 +235,8 @@ In this mode, all messages in the file are sampled randomly when making requests
 ]
 ```
 
-In addition, when `--prevent-server-caching=true`, every message in each request payload is prefixed with a random string to force the inference endpoint to process each request without any optimization/caching that might occur if workloads are the same. This ensures that the results observed while running the tool are the worst case scenario for given traffic shape. For example:
+#### Prevent Server Caching
+When `--prevent-server-caching=true`, every message in each request payload is prefixed with a random string to force the inference endpoint to process each request without any optimization/caching that might occur if workloads are the same. This ensures that the results observed while running the tool are the worst case scenario for given traffic shape. For example:
 
 |initial request|request with random prefixes|
 |-|-|
@@ -243,6 +244,13 @@ In addition, when `--prevent-server-caching=true`, every message in each request
 ||{"role": "user", "content": "1704441963.715898 Can you explain how photosynthesis works?"}|
 
 Setting `--prevent-server-caching=false` is only recommended when a sufficiently large replay dataset is available (e.g. at least double the number of messages than the total number of requests to be made across all test runs in a session). If the cache needs to be cleared/reset for additional runs, it is recommended that the PTU model deployment should be deleted and recreated in order to reload the model with an empty cache.
+
+#### Adjust for Network Latency
+The `--adjust-for-network-latency` argument will adjust all aggregate statistics based on the network delay (using a ping test) between the testing machine and the model endpoint. This makes it easy to test models across different regions from a single machine without having the results influenced by the time it takes for requests to traverse the globe. Note that this will only adjust the results of aggregate statistics (e.g. those listed in the Output Fields section down below); all individual call results will maintain their original timestamps and will need to be adjusted separtely.
+
+#### Log Request Content
+At the end of each bencmark run, the raw call statistics (such as request start time, time of first token, request end time, and num context and generation tokens) will be logged for every request that occurred within the test (both the successes and failures). If the `--log-request-content` argument is set to `true`, this dump will also include the raw input messages and output completion for each request. This is useful in cases where you want to compare the generated content between different endpoints.
+
 
 ### Output fields
 

--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -46,6 +46,7 @@ def main():
     load_parser.add_argument("--presence-penalty", type=float, help="Request frequency_penalty.")
     load_parser.add_argument("--temperature", type=float, help="Request temperature.")
     load_parser.add_argument("--top-p", type=float, help="Request top_p.")
+    load_parser.add_argument("--adjust-for-network-latency", type=str2bool, nargs='?', help="If True, will subtract base network delay from all latency measurements (based on ping). Only use this when trying to simulate the results as if the test machine was in the same data centre as the endpoint. Defaults to False.", const=True, default=False)
     load_parser.add_argument("-f", "--output-format", type=str, default="human", help="Output format.", choices=["jsonl", "human"])
     load_parser.add_argument("--log-save-dir", type=str, help="If provided, will save stddout to this directory. Filename will include important run parameters.")
     load_parser.add_argument("--log-request-content", type=str2bool, nargs='?', help="If True, will log the raw input and output tokens of every request. Defaults to False.", const=True, default=False)

--- a/benchmark/contrib/batch_runner.py
+++ b/benchmark/contrib/batch_runner.py
@@ -113,6 +113,14 @@ def parse_args():
         default=False,
     )
     parser.add_argument(
+        "--adjust-for-network-latency", 
+        type=str2bool, 
+        nargs='?', 
+        help="If True, will subtract base network delay from all latency measurements (based on ping). Only use this when trying to simulate the results as if the test machine was in the same data centre as the endpoint. Defaults to False.", 
+        const=True, 
+        default=False
+    )
+    parser.add_argument(
         "--retry",
         type=str,
         default="none",
@@ -181,6 +189,7 @@ def benchmark_args_to_exec_str(
     presence_penalty: Optional[float] = None,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
+    adjust_for_network_latency: Optional[bool] = None,
     log_save_dir: Optional[str] = None,
     log_request_content: Optional[bool] = None,
     api_key_env: str = "OPENAI_API_KEY",
@@ -206,6 +215,8 @@ def benchmark_args_to_exec_str(
         cmd += f" --requests {requests}"
     if run_end_condition_mode is not None:
         cmd += f" --run-end-condition-mode {run_end_condition_mode}"
+    if adjust_for_network_latency is not None:
+        cmd += f" --adjust-for-network-latency {adjust_for_network_latency}"
     if log_save_dir is not None:
         cmd += f" --log-save-dir {log_save_dir}"
     if log_request_content is not None:
@@ -289,6 +300,7 @@ def run_benchmark_batch(
     requests: Optional[int],
     run_end_condition_mode: str,
     clients: Optional[int],
+    adjust_for_network_latency: Optional[bool],
     log_save_dir: str,
     log_request_content: Optional[bool],
     prevent_server_caching: bool,
@@ -312,6 +324,7 @@ def run_benchmark_batch(
     :param requests: Max number of requests in each run.
     :param run_end_condition_mode: Determines whether both the `requests` and `duration` args must be reached before ending the run ('and'), or whether to end the run either either arg is reached ('or'). Defaults to 'or'.
     :param clients: Number of clients to use in each test.
+    :param adjust_for_network_latency: If True, will subtract base network delay from all latency measurements (based on ping). Only use this when trying to simulate the results as if the test machine was in the same data centre as the endpoint.
     :param log_save_dir: Will save all logs to this directory.
     :param log_request_content: If True, will log the raw input and output content of every request.
     :param prevent_server_caching: Whether to prevent server caching in each test.
@@ -417,6 +430,7 @@ def run_benchmark_batch(
             rate=rate,
             log_save_dir=log_save_dir,
             log_request_content=log_request_content,
+            adjust_for_network_latency=adjust_for_network_latency,
             aggregation_window=aggregation_window,
             duration=duration,
             requests=requests,
@@ -518,6 +532,7 @@ def main():
                 clients=args.clients,
                 log_save_dir=args.log_save_dir,
                 log_request_content=args.log_request_content,
+                adjust_for_network_latency=args.adjust_for_network_latency,
                 prevent_server_caching=args.prevent_server_caching,
                 start_ptum_runs_at_full_utilization=args.start_ptum_runs_at_full_utilization,
                 frequency_penalty=args.frequency_penalty,
@@ -556,6 +571,7 @@ def main():
                     clients=args.clients,
                     log_save_dir=args.log_save_dir,
                     log_request_content=args.log_request_content,
+                    adjust_for_network_latency=args.adjust_for_network_latency,
                     prevent_server_caching=args.prevent_server_caching,
                     start_ptum_runs_at_full_utilization=args.start_ptum_runs_at_full_utilization,
                     frequency_penalty=args.frequency_penalty,

--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -103,6 +103,7 @@ def load(args):
         "presence_penalty": args.presence_penalty,
         "temperature": args.temperature,
         "top_p": args.top_p,
+        "adjust_for_network_latency": args.adjust_for_network_latency,
         "output_format": args.output_format,
         "log_request_content": args.log_request_content,
     }

--- a/benchmark/loadcmd.py
+++ b/benchmark/loadcmd.py
@@ -5,10 +5,13 @@ import json
 import logging
 import os
 import sys
+import time
 from typing import Iterable, Iterator
+from urllib.parse import urlsplit
 
 import aiohttp
 import requests
+from ping3 import ping
 
 from benchmark.messagegeneration import (
     BaseMessagesGenerator,
@@ -108,7 +111,9 @@ def load(args):
 
     api_key = os.getenv(args.api_key_env)
     if not api_key:
-        raise ValueError(f"API key is not set - make sure to set the environment variable '{args.api_key_env}'")
+        raise ValueError(
+            f"API key is not set - make sure to set the environment variable '{args.api_key_env}'"
+        )
     # Check if endpoint is openai.com, otherwise we will assume it is Azure OpenAI
     is_openai_com_endpoint = "openai.com" in args.api_base_endpoint[0]
     # Set URL
@@ -127,7 +132,6 @@ def load(args):
     if args.rate is not None and args.rate > 0:
         rate_limiter = RateLimiter(args.rate, 60)
 
-    max_tokens = args.max_tokens
     # Check model name in order to correctly estimate tokens
     if is_openai_com_endpoint:
         model = args.deployment
@@ -147,6 +151,16 @@ def load(args):
         model = response.json()["model"]
     logging.info(f"model detected: {model}")
 
+    if args.adjust_for_network_latency:
+        logging.info("checking ping to endpoint...")
+        network_latency_adjustment = measure_avg_ping(url)
+        logging.info(
+            f"average ping to endpoint: {int(network_latency_adjustment*1000)}ms. this will be subtracted from all aggregate latency metrics."
+        )
+    else:
+        network_latency_adjustment = 0
+
+    max_tokens = args.max_tokens
     if args.context_generation_method == "generate":
         context_tokens = args.context_tokens
         if args.shape_profile == "balanced":
@@ -211,6 +225,7 @@ def load(args):
         run_end_condition_mode=args.run_end_condition_mode,
         json_output=args.output_format == "jsonl",
         log_request_content=args.log_request_content,
+        network_latency_adjustment=network_latency_adjustment,
     )
 
 
@@ -227,6 +242,7 @@ def _run_load(
     run_end_condition_mode="or",
     json_output=False,
     log_request_content=False,
+    network_latency_adjustment=0
 ):
     aggregator = _StatsAggregator(
         window_duration=aggregation_duration,
@@ -235,6 +251,7 @@ def _run_load(
         clients=max_concurrency,
         json_output=json_output,
         log_request_content=log_request_content,
+        network_latency_adjustment=network_latency_adjustment,
     )
     requester = OAIRequester(api_key, url, backoff=backoff)
 
@@ -315,3 +332,22 @@ def _validate(args):
         raise ValueError("presence-penalty must be between -2.0 and 2.0")
     if args.temperature is not None and (args.temperature < 0 or args.temperature > 2):
         raise ValueError("temperature must be between 0 and 2.0")
+
+
+def measure_avg_ping(url: str, num_requests: int = 5, max_time: int = 5):
+    """Measures average network latency for a given URL by sending multiple ping requests."""
+    ping_url = urlsplit(url).netloc
+    latencies = []
+    latency_test_start_time = time.time()
+    while (
+        len(latencies) < num_requests
+        and time.time() < latency_test_start_time + max_time
+    ):
+        delay = ping(ping_url, timeout=5)
+        latencies.append(delay)
+        if delay < 0.5:  # Ensure at least 0.5 seconds between requests
+            time.sleep(0.5 - delay)
+    avg_latency = round(
+        sum(latencies) / len(latencies), 2
+    )  # exclude first request, this is usually 3-5x slower
+    return avg_latency

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ asyncio
 aiohttp
 pandas
 pillow
+ping3


### PR DESCRIPTION
Add the `adjust-for-network-latency` flag to the `bench` and `batch_runner` CLIs. This adds a ping check to the start of each benchmark, which is then used to automatically adjust all aggregate statistics by this amount. For example, if the ping to the model endpoint at the start of the test is 0.1 seconds, then all aggregate latency statistics (TTFT, e2e latency, TBT) will be reduced by 0.1 seconds when they are logged.