### PR TITLE
Handle deprecated PTU-M utilization header, handle 429s gracefully

### DIFF
--- a/benchmark/oairequester.py
+++ b/benchmark/oairequester.py
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 import asyncio
+import json
 import logging
 import time
-from typing import Optional
-import json
 import traceback
+from typing import Optional
 
 import aiohttp
 import backoff
@@ -140,7 +140,7 @@ class OAIRequester:
         if response.status != 200:
             stats.response_end_time = time.time()
         if response.status != 200 and response.status != 429:
-            logging.warning(f"call failed: {REQUEST_ID_HEADER}={response.headers[REQUEST_ID_HEADER]} {response.status}: {response.reason}")
+            logging.warning(f"call failed: {REQUEST_ID_HEADER}={response.headers.get(REQUEST_ID_HEADER, None)} {response.status}: {response.reason}")
         if self.backoff:
             response.raise_for_status()
         if response.status == 200:


### PR DESCRIPTION
* Within the batch_runner script, Removes the `start-ptum-runs-at-full-utilization` parameter in favor of a new `run-warmup-load-until-429-occurs` argument. PTU-M warmup runs will now terminate with either a utilization header OR when the first 429 occurs. This is a response to the deprecation of the PTU utilization header from PTU-M endpoint responses (which would render the warmup check useless since no utilization header was ever returned).
* This means users now need to explicitly set the `run-warmup-load-until-429-occurs` argument to `true` for when they want to warm-up a PTU-M endpoint prior to a benchmark run.
* Updates the model type check within the main benchmarking script to automatically retry when a 429 error is returned on the checking request.